### PR TITLE
Change build jobs to use ubuntu latest

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -28,7 +28,7 @@ defaults:
 
 jobs:
   build:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
     # Only run this workflow for internally triggered events
     if: |
       github.event.pull_request.head.repo.full_name == github.repository ||

--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -29,7 +29,7 @@ defaults:
 
 jobs:
   build:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
     # Only run this workflow for internally triggered events
     if: |
       github.event.pull_request.head.repo.full_name == github.repository ||

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes \
     supervisor curl cron certbot nginx gnupg wget netcat openssh-client \
     software-properties-common gettext \
-    python3-pip python-setuptools git ca-certificates-java \
+    python3-pip python-setuptools git ca-certificates-java ca-certificates \
+    nfs-common nfs-kernel-server \
   && wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | apt-key add - \
   && echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list \
   && apt-get update && apt-get install --no-install-recommends --yes temurin-17-jdk \


### PR DESCRIPTION

## Description

Changes the entrypoint.sh and Dockerfile to make Appsmith mount the Google Filestore volume at /appsmiht-stacks. This allows for CloudRun to be used  as a hosting platform.

#### Type of change
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Testing
- [x] Manual

Locally created the image and pushed said image to our GCP Container Registry. From her, I was able to run the CloudRun build without the build failing. However, I will note that the application never cam into a working state because of the following error;

```UncategorizedMongoDbException: Exception authenticating MongoCredential```

I suspect that this has something to do with the default MongoDB set up as I didn't configure an external MongoDB instance.  

#### Issues raised during DP testing

 - Default Mongo set up does not work with MongoDB when using a mounted volume
 - Had to change GHA image names as GHA could not resolve the original names. This had to be done to get the required `dist` packages to adjust the image locally.
